### PR TITLE
[feat](tracked-entity-bulk-actions): add overwrite status action

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-06-20T02:30:48.905Z\n"
-"PO-Revision-Date: 2025-06-20T02:30:48.905Z\n"
+"POT-Creation-Date: 2025-07-01T16:07:43.436Z\n"
+"PO-Revision-Date: 2025-07-01T16:07:43.437Z\n"
 
 msgid "Choose one or more dates..."
 msgstr "Choose one or more dates..."
@@ -1834,6 +1834,9 @@ msgstr "Overwrite Profile"
 
 msgid "Profiles"
 msgstr "Profiles"
+
+msgid "Overwrite Status"
+msgstr "Overwrite Status"
 
 msgid "Overwrite Firmware"
 msgstr "Overwrite Firmware"

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/shared/actions/actionTypes.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/shared/actions/actionTypes.js
@@ -10,6 +10,7 @@ export const actionTypes = {
         updateProfile: 'updateProfile',
         overwriteProfile: 'overwriteProfile',
         overwriteFirmware: 'overwriteFirmware',
+        overwriteStatus: 'overwriteStatus',
         updateFirmware: 'updateFirmware',
         clearRequestedFirmware: 'clearRequestedFirmware',
         updateAPN: 'updateAPN',

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/shared/actions/actions.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/shared/actions/actions.js
@@ -137,6 +137,36 @@ export const actions = (props: {enrollmentId: string}, attributes: Attributes): 
         },
         smsCommand: null,
     },
+    [actionTypes.updates.overwriteStatus]: {
+        title: i18n.t('Overwrite Status'),
+        fields: [
+            {
+                id: 'status_select', // ID of the field (e.g. used as a Key for the component)
+                formValueField: 'requestedStatus', // key for the values object, and what we send in the SMS command request body
+                type: FIELD_COMPONENT_TYPE.SELECT, // Type of component
+                label: i18n.t('Status'), // Label of the component
+                params: {
+                    required: true,
+                },
+                query: {
+                    optionSets: getOptionSetQuery(OPTION_SET_IDS.STATUS),
+                    attributes: getEnrollmentAttributesQuery(props.enrollmentId),
+                },
+                defaultValueField: ATTRIBUTE_IDS.DV_REQUESTED_STATUS,
+                // values: [ // hardcoded values (when no http request is needed to get the values for the component)
+                //   { label: "Firmware v1", value: "1" },
+                //   { label: "Firmware v2", value: "2" },
+                //   { label: "Firmware v3", value: "3" },
+                // ],
+            },
+        ],
+        confirmationMessage,
+        updateTEA: {
+            attribute: ATTRIBUTE_IDS.DV_REQUESTED_STATUS,
+            formValueField: 'requestedStatus',
+        },
+        smsCommand: null,
+    },
     [actionTypes.updates.overwriteFirmware]: {
         title: i18n.t('Overwrite Firmware'),
         fields: [

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/shared/actions/tabsDeviceActions.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/shared/actions/tabsDeviceActions.js
@@ -93,6 +93,11 @@ export const tabsDeviceActions: TabsDeviceActions = [
                 label: i18n.t('Update Band Priority'),
                 type: actionTypes.updates.updateBandPriority,
             },
+            {
+                label: i18n.t('Overwrite Status'),
+                type: actionTypes.updates.overwriteStatus,
+            },
+
         ],
     },
     {

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/shared/constants/attributeIds.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/shared/constants/attributeIds.js
@@ -28,6 +28,7 @@ export const ATTRIBUTE_IDS = {
     DV_VIRTUAL_GATEWAY: 'EofngtG9vPc',
     DV_APN: 'ouA9SUIws2y',
     DV_REQUESTED_PROFILE: 'k2THsaeHpDq',
+    DV_REQUESTED_STATUS: 'u68L3OwMhqV',
     DV_LAST_SEEN: 'Zss3gfqukHT',
 };
 

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/shared/constants/optionSetIds.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/shared/constants/optionSetIds.js
@@ -5,4 +5,5 @@ export const OPTION_SET_IDS = {
     FIRMWARE: 'EMjEZtgDEHg',
     UPDATE_INSTANCE_FROM: 'AMILIACT5KR',
     UPDATE_INSTANCE_TO: 'L7rGiW6uWDk',
+    STATUS: 'bJOdSN2z4y7',
 };


### PR DESCRIPTION
Add support for overwriting device status in bulk actions. This includes option set ID, attribute ID, action type, and the corresponding action implementation.
![Screenshot 2025-07-01 at 22 40 41](https://github.com/user-attachments/assets/712681b4-8124-4bdd-8eaa-4f22940d9740)
![Screenshot 2025-07-01 at 22 41 00](https://github.com/user-attachments/assets/e6ed9a06-2eb4-4de0-9cef-c025fa6a0da9)
